### PR TITLE
Align quick profile compression percentages with profile targets

### DIFF
--- a/create_compression_config.py
+++ b/create_compression_config.py
@@ -81,9 +81,9 @@ class OptimizedCompressionConfigCreator:
     def _quick_profile_selection(self) -> str:
         """Selección rápida de perfil"""
         print("\n📐 Selecciona un perfil de compresión:")
-        print("\n[1] 🛡️  Conservative (15% compresión, 95%+ rendimiento)")
-        print("[2] ⚖️  Balanced (35% compresión, 90% rendimiento)")
-        print("[3] 🚀 Aggressive (60% compresión, 80% rendimiento)")
+        print("\n[1] 🛡️  Conservative (30% compresión, 95%+ rendimiento)")
+        print("[2] ⚖️  Balanced (50% compresión, 90% rendimiento)")
+        print("[3] 🚀 Aggressive (70% compresión, 80% rendimiento)")
         print("[4] 🔧 Custom (configuración manual)")
         
         while True:


### PR DESCRIPTION
## Summary
- Update quick profile menu to display 30%, 50%, and 70% compression levels
- Ensure quick profiles align with `target_compression` values in `compression_profiles`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899c684a8308331a6796ce011b44854