### PR TITLE
Remove duplicate datasets requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,6 @@ rich>=13.7.0
 # Data handling
 pandas>=2.1.0
 pyarrow>=14.0.0
-datasets>=2.14.0
 
 # System and file handling
 psutil>=5.9.0


### PR DESCRIPTION
## Summary
- remove duplicate `datasets` requirement and keep version 2.15.0

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899c67a8a6c8331bf954f8a524419bb