### PR TITLE
Handle normalization layers in compression profiles

### DIFF
--- a/create_compress/compression_config_manager.py
+++ b/create_compress/compression_config_manager.py
@@ -226,10 +226,19 @@ class CompressionConfigManager:
         # Copiar config de capas del perfil seleccionado
         layer_configs = profile.get('layer_configs', {}).copy()
 
-        # Asegurar que todos los tipos detectados tengan al menos una
-        # configuración "sin compresión" para evitar advertencias durante
-        # la aplicación de la compresión.
-        for layer_type in self.layer_types.keys():
+        # Tipos estándar que deben existir incluso si no aparecen en el
+        # análisis del modelo. Esto garantiza que capas como las de
+        # normalización tengan una configuración explícita y puedan ser
+        # modificadas posteriormente por el usuario.
+        standard_types = {
+            'embedding', 'attention', 'ffn', 'linear', 'normalization',
+            'output', 'conv', 'other', 'skip'
+        }
+
+        # Asegurar que todos los tipos detectados o estándar tengan al menos
+        # una configuración "sin compresión" para evitar errores durante la
+        # aplicación.
+        for layer_type in set(self.layer_types.keys()) | standard_types:
             if layer_type not in layer_configs:
                 layer_configs[layer_type] = {
                     'methods': [{'name': 'none', 'strength': 0.0}],

--- a/create_compress/compression_profiles.py
+++ b/create_compress/compression_profiles.py
@@ -91,6 +91,12 @@ COMPRESSION_PROFILES = {
                 ],
                 'total_compression_ratio': 0.5
             },
+            'normalization': {
+                'methods': [
+                    {'name': 'none', 'strength': 0.0}
+                ],
+                'total_compression_ratio': 0.0
+            },
             'other': {
                 'methods': [
                     {'name': 'magnitude_pruning', 'strength': 0.4}
@@ -162,6 +168,12 @@ COMPRESSION_PROFILES = {
                 ],
                 'total_compression_ratio': 0.7
             },
+            'normalization': {
+                'methods': [
+                    {'name': 'none', 'strength': 0.0}
+                ],
+                'total_compression_ratio': 0.0
+            },
             'other': {
                 'methods': [
                     {'name': 'magnitude_pruning', 'strength': 0.6},
@@ -224,6 +236,12 @@ COMPRESSION_PROFILES = {
                 ],
                 'total_compression_ratio': 0.35
             },
+            'normalization': {
+                'methods': [
+                    {'name': 'none', 'strength': 0.0}
+                ],
+                'total_compression_ratio': 0.0
+            },
             'other': {
                 'methods': [
                     {'name': 'magnitude_pruning', 'strength': 0.5}
@@ -270,6 +288,12 @@ COMPRESSION_PROFILES = {
                     {'name': 'int8_quantization', 'strength': 0.8}
                 ],
                 'total_compression_ratio': 0.5
+            },
+            'normalization': {
+                'methods': [
+                    {'name': 'none', 'strength': 0.0}
+                ],
+                'total_compression_ratio': 0.0
             },
             'other': {
                 'methods': [
@@ -318,6 +342,12 @@ COMPRESSION_PROFILES = {
                     {'name': 'int4_quantization', 'strength': 0.8}
                 ],
                 'total_compression_ratio': 0.6
+            },
+            'normalization': {
+                'methods': [
+                    {'name': 'none', 'strength': 0.0}
+                ],
+                'total_compression_ratio': 0.0
             },
             'other': {
                 'methods': [


### PR DESCRIPTION
## Summary
- include normalization layer configs in all predefined compression profiles
- ensure standard layer types like normalization always have explicit config when applying a profile

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c4290a7848331a9e5f37b2729c2ca