### PR TITLE
Fix randomized SVD orientation and improve save error handling

### DIFF
--- a/apply_compression.py
+++ b/apply_compression.py
@@ -263,7 +263,9 @@ class ModelCompressor:
             else:
                 # Si después de varios intentos sigue fallando, propagar el
                 # último error registrado para que el usuario tenga visibilidad.
-                raise last_error or RuntimeError(
+                if last_error is not None:
+                    raise last_error
+                raise RuntimeError(
                     "Fallo al guardar el modelo incluso tras aumentar el límite de recursión"
                 )
             

--- a/create_compress/compression_methods.py
+++ b/create_compress/compression_methods.py
@@ -290,9 +290,12 @@ class LowRankApproximation(CompressionMethod):
         B = Q.T @ matrix
         U_tilde, S, Vh = torch.linalg.svd(B, full_matrices=False)
         U = Q @ U_tilde
-        
-        # Retornar solo los primeros 'rank' componentes
-        return U[:, :rank], S[:rank], Vh[:rank, :]
+
+        # Retornar solo los primeros 'rank' componentes.
+        # ``torch.linalg.svd`` devuelve ``Vh`` con forma (rank, n), por lo que
+        # lo transponemos para alinear con la convención de ``torch.svd_lowrank``
+        # que retorna ``V`` con forma (n, rank).
+        return U[:, :rank], S[:rank], Vh[:rank, :].T
     
     def estimate_compression(self, module: nn.Module, config: Dict[str, Any]) -> float:
         """Estima compresión por bajo rango"""

--- a/tests/test_compression_engine.py
+++ b/tests/test_compression_engine.py
@@ -1,8 +1,14 @@
 import torch
+import os
+import sys
 import torch.nn as nn
 import pytest
 
+# Asegurar que el paquete del proyecto esté en el path de importación
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 from create_compress.compression_engine import CompressionEngine, QuantizedLinear
+from create_compress.compression_methods import LowRankApproximation
 
 
 def test_calculate_quantization_params_constant_tensor():
@@ -39,3 +45,12 @@ def test_compress_layer_int8_quantization():
     assert isinstance(compressed, QuantizedLinear)
     assert result.success
     assert result.compression_ratio > 0
+
+
+def test_randomized_svd_returns_correct_shapes():
+    method = LowRankApproximation()
+    weight = torch.randn(50, 30)
+    U, S, V = method._randomized_svd(weight, rank=10)
+    assert U.shape == (50, 10)
+    assert S.shape == (10,)
+    assert V.shape == (30, 10)


### PR DESCRIPTION
## Summary
- fix LowRankApproximation randomized SVD to return V with correct orientation
- improve model saving retries to rethrow last error properly
- add unit test covering randomized SVD shapes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c65e2ec7c8331bd0ca66b54320dd7