### PR TITLE
Handle randomized SVD reconstruction and improve save failure message

### DIFF
--- a/apply_compression.py
+++ b/apply_compression.py
@@ -261,9 +261,15 @@ class ModelCompressor:
                     )
                     sys.setrecursionlimit(new_limit)
             else:
-                # Si después de varios intentos sigue fallando, propagar el
-                # último error registrado para que el usuario tenga visibilidad.
-                raise last_error or RuntimeError(
+                # Si después de varios intentos sigue fallando, propagar un
+                # error más descriptivo encadenado con el último
+                # ``RecursionError`` observado.  Esto evita mensajes crípticos
+                # como "No active exception to reraise".
+                if last_error is not None:
+                    raise RuntimeError(
+                        "Fallo al guardar el modelo incluso tras aumentar el límite de recursión"
+                    ) from last_error
+                raise RuntimeError(
                     "Fallo al guardar el modelo incluso tras aumentar el límite de recursión"
                 )
             


### PR DESCRIPTION
## Summary
- avoid shape mismatches by reconstructing low-rank weights using column scaling and `V.t()`
- return V from randomized SVD with consistent orientation
- raise a clearer error when model saving still fails after increasing recursion limit
- expand unit test to cover reconstruction using randomized SVD

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c65e2ec7c8331bd0ca66b54320dd7